### PR TITLE
refactor(tests): replace FluentAssertions with Shouldly for assertions

### DIFF
--- a/test/CurrencyDotNet.UnitTests/CurrencyDotNet.UnitTests.csproj
+++ b/test/CurrencyDotNet.UnitTests/CurrencyDotNet.UnitTests.csproj
@@ -10,8 +10,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+        <PackageReference Include="Shouldly" Version="4.3.0" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/CurrencyDotNet.UnitTests/CurrencyTests.cs
+++ b/test/CurrencyDotNet.UnitTests/CurrencyTests.cs
@@ -1,4 +1,4 @@
-using FluentAssertions;
+using Shouldly;
 
 namespace CurrencyDotNet.UnitTests;
 
@@ -19,16 +19,16 @@ public class CurrencyTests
         );
 
         // Assert
-        currency.IsoCode.Should().Be(isoCode);
-        currency.NumericCode.Should().Be(numericCode);
-        currency.Name.Should().Be(name);
-        currency.Symbol.Should().Be(symbol);
-        currency.DecimalPlaces.Should().Be(decimalPlaces);
-        currency.AltName.Should().Be(altName);
-        currency.Locations.Should().BeEquivalentTo(locations);
-        currency.WikipediaUrl.Should().Be(wikipediaUrl);
-        currency.AlternativeSymbols.Should().BeEquivalentTo(alternativeSymbols);
-        currency.Id.Should().NotBe(Guid.Empty);
+        currency.IsoCode.ShouldBe(isoCode);
+        currency.NumericCode.ShouldBe(numericCode);
+        currency.Name.ShouldBe(name);
+        currency.Symbol.ShouldBe(symbol);
+        currency.DecimalPlaces.ShouldBe(decimalPlaces);
+        currency.AltName.ShouldBe(altName);
+        currency.Locations.ShouldBe(locations);
+        currency.WikipediaUrl.ShouldBe(wikipediaUrl);
+        currency.AlternativeSymbols.ShouldBe(alternativeSymbols);
+        currency.Id.ShouldNotBe(Guid.Empty);
     }
 
     [Theory]
@@ -41,7 +41,7 @@ public class CurrencyTests
         );
 
         // Assert
-        act.Should().Throw<ArgumentOutOfRangeException>();
+        act.ShouldThrow<ArgumentOutOfRangeException>();
     }
     
     [Theory]
@@ -56,7 +56,7 @@ public class CurrencyTests
         var result = Currency.WithCode(isoCode);
 
         // Assert
-        result.Should().BeEquivalentTo(expectedCurrency);
+        result.ShouldBeEquivalentTo(expectedCurrency);
     }
     
 }


### PR DESCRIPTION
Switched all test assertions from FluentAssertions to Shouldly because FluentAssertions is moving to a commercial license. This ensures the project remains free of commercial dependencies.